### PR TITLE
fix thumbnail behavior

### DIFF
--- a/android/src/main/java/xyz/justsoft/video_thumbnail/VideoThumbnailPlugin.java
+++ b/android/src/main/java/xyz/justsoft/video_thumbnail/VideoThumbnailPlugin.java
@@ -208,7 +208,7 @@ public class VideoThumbnailPlugin implements MethodCallHandler {
             if (targetH != 0 || targetW != 0) {
                 if (android.os.Build.VERSION.SDK_INT >= 27 && targetH != 0 && targetW != 0) {
                     // API Level 27
-                    bitmap = retriever.getScaledFrameAtTime(timeMs * 1000, 0, targetW, targetH);
+                    bitmap = retriever.getScaledFrameAtTime(timeMs * 1000, MediaMetadataRetriever.OPTION_CLOSEST_SYNC, targetW, targetH);
                 } else {
                     bitmap = retriever.getFrameAtTime(timeMs * 1000);
                     if (bitmap != null) {

--- a/ios/Classes/VideoThumbnailPlugin.m
+++ b/ios/Classes/VideoThumbnailPlugin.m
@@ -96,6 +96,8 @@
     
     imgGenerator.appliesPreferredTrackTransform = TRUE;
     imgGenerator.maximumSize = CGSizeMake((CGFloat)maxw, (CGFloat)maxh);
+    imgGenerator.requestedTimeToleranceBefore = kCMTimeZero;
+    imgGenerator.requestedTimeToleranceAfter = kCMTimeZero;
     
     NSError *error = nil;
     CGImageRef cgImage = [imgGenerator copyCGImageAtTime:CMTimeMake(timeMs, 1000) actualTime:nil error:&error];


### PR DESCRIPTION
for Android: use OPTION_CLOSEST_SYNC (default is OPTION_PREVIOUS_SYNC) in getScaledFrameAtTime to match the behavior of getFrameAtTime
for iOS: use accurate time in generateThumbnail because their devices can do this very quick