### PR TITLE
Update Documentation - Create Thumbnail From Root Assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,5 +50,22 @@ final fileName = await VideoThumbnail.thumbnailFile(
 );
 ```
 
+**Generate a thumbnail file from video Assets declared in pubspec.yaml**
+```dart
+final byteData = await rootBundle.load("assets/my_video.mp4");
+Directory tempDir = await getTemporaryDirectory();
+
+File tempVideo = File("${tempDir.path}/assets/my_video.mp4")
+  ..createSync(recursive: true)
+  ..writeAsBytesSync(byteData.buffer.asUint8List(byteData.offsetInBytes, byteData.lengthInBytes));
+
+final fileName = await VideoThumbnail.thumbnailFile(
+  video: tempVideo.path,
+  thumbnailPath: (await getTemporaryDirectory()).path,
+  imageFormat: ImageFormat.PNG,  
+  quality: 100,
+);
+```
+
 ## Notes
 Fork or pull requests are always welcome. Currently it seems have a little performance issue while generating WebP thumbnail by using libwebp under iOS.


### PR DESCRIPTION
Add documentation on how to create a thumbnail from video assets declared in pubspec.yaml.

When using **VideoThumbnail.thumbnailData** or **VideoThumbnail.thumbnailFile** to create a thumbnail of the video located in root assets directly will throw _MissingPluginException(No implementation found for method file on channel video_thumbnail)_. Even though the video is playable and already declared in pubspec.yaml.

So to handle video located in root assets, we load and create a temporary File, then provide the path to **VideoThumbnail.thumbnailFile**.