### PR TITLE
Fetch closest frame instead of closest keyframe

### DIFF
--- a/android/src/main/java/xyz/justsoft/video_thumbnail/VideoThumbnailPlugin.java
+++ b/android/src/main/java/xyz/justsoft/video_thumbnail/VideoThumbnailPlugin.java
@@ -206,9 +206,9 @@ public class VideoThumbnailPlugin implements FlutterPlugin, MethodCallHandler {
             if (targetH != 0 || targetW != 0) {
                 if (android.os.Build.VERSION.SDK_INT >= 27 && targetH != 0 && targetW != 0) {
                     // API Level 27
-                    bitmap = retriever.getScaledFrameAtTime(timeMs * 1000, MediaMetadataRetriever.OPTION_CLOSEST_SYNC, targetW, targetH);
+                    bitmap = retriever.getScaledFrameAtTime(timeMs * 1000, MediaMetadataRetriever.OPTION_CLOSEST, targetW, targetH);
                 } else {
-                    bitmap = retriever.getFrameAtTime(timeMs * 1000);
+                    bitmap = retriever.getFrameAtTime(timeMs * 1000, MediaMetadataRetriever.OPTION_CLOSEST);
                     if (bitmap != null) {
                         int width = bitmap.getWidth();
                         int height = bitmap.getHeight();
@@ -223,7 +223,7 @@ public class VideoThumbnailPlugin implements FlutterPlugin, MethodCallHandler {
                     }
                 }
             } else {
-                bitmap = retriever.getFrameAtTime(timeMs * 1000);
+                bitmap = retriever.getFrameAtTime(timeMs * 1000, MediaMetadataRetriever.OPTION_CLOSEST);
             }
         } catch (IllegalArgumentException ex) {
             ex.printStackTrace();


### PR DESCRIPTION
Exporting keyframes only leads to extremely confusing results. I believe using the OPTION_CLOSEST to export interpolated frames delivers results that are closer to what a user of this API would expect. 

OPTION_CLOSEST is slower, so adding an optional flag in the API could be prudent.