### PR TITLE
thumbnailPath arg is Required in thumbnailFile method

### DIFF
--- a/lib/video_thumbnail.dart
+++ b/lib/video_thumbnail.dart
@@ -27,7 +27,7 @@ class VideoThumbnail {
   static Future<String?> thumbnailFile(
       {required String video,
       Map<String, String>? headers,
-      String? thumbnailPath,
+      required String thumbnailPath,
       ImageFormat imageFormat = ImageFormat.PNG,
       int maxHeight = 0,
       int maxWidth = 0,


### PR DESCRIPTION
Internally it was expecting thumbnailPath argument as "path" for "file" method which is iinvoked through thumbnailFile method.
So it should be marked as required 