### PR TITLE
Update build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,25 +4,30 @@ version '1.0-SNAPSHOT'
 buildscript {
     repositories {
         google()
-        jcenter()
+        // jcenter() is verouderd en zou idealiter vervangen moeten worden door mavenCentral() indien mogelijk
+        mavenCentral() 
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0'
+        // Update de classpath naar een nieuwere versie van de Android Gradle Plugin
+        classpath 'com.android.tools.build:gradle:7.0.0' // Of een nog nieuwere versie indien compatibel
     }
 }
 
 rootProject.allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 33
+    compileSdkVersion 33 // Zorg ervoor dat deze overeenkomt met de laatste beschikbare versie of jouw specifieke vereisten
+
+    // Voeg de namespace toe zoals vereist door de nieuwere versies van de Android Gradle Plugin
+    namespace 'xyz.justsoft.video_thumbnail'
 
     defaultConfig {
         minSdkVersion 16

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,13 +4,13 @@ version '1.0-SNAPSHOT'
 buildscript {
     repositories {
         google()
-        // jcenter() is verouderd en zou idealiter vervangen moeten worden door mavenCentral() indien mogelijk
+        // jcenter() is deprecated and should ideally be replaced by mavenCentral() if possible
         mavenCentral() 
     }
 
     dependencies {
-        // Update de classpath naar een nieuwere versie van de Android Gradle Plugin
-        classpath 'com.android.tools.build:gradle:7.0.0' // Of een nog nieuwere versie indien compatibel
+        // Update the classpath to a newer version of the Android Gradle Plugin
+        classpath 'com.android.tools.build:gradle:7.0.0' // Or a newer version if compatible
     }
 }
 
@@ -24,9 +24,9 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 33 // Zorg ervoor dat deze overeenkomt met de laatste beschikbare versie of jouw specifieke vereisten
+    compileSdkVersion 34 // Ensure this matches the latest available version
 
-    // Voeg de namespace toe zoals vereist door de nieuwere versies van de Android Gradle Plugin
+    // Add the namespace as required by the newer versions of the Android Gradle Plugin
     namespace 'xyz.justsoft.video_thumbnail'
 
     defaultConfig {


### PR DESCRIPTION
Upgraded Android Gradle Plugin: Moved from AGP version 4.1.0 to 7.0.0. This upgrade allows us to take advantage of the latest features, performance improvements, and bug fixes introduced in recent AGP releases.

Namespace Specification: Added the namespace declaration in the build.gradle file to comply with the new AGP requirements. This ensures our project adheres to the latest Android build standards.

Repository Migration: Transitioned from jcenter() to mavenCentral() for fetching dependencies. This change is in response to the deprecation of JCenter as a repository, ensuring our project dependencies are fetched from a reliable and updated source.