### PR TITLE
Fix/add namespace

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,6 +22,8 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
+    namespace 'com.video.thumbnail'
+
     compileSdkVersion 33
 
     defaultConfig {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,7 +22,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    namespace 'com.video.thumbnail'
+    namespace 'xyz.justsoft.video_thumbnail'
 
     compileSdkVersion 33
 

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,3 +1,2 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="xyz.justsoft.video_thumbnail">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 </manifest>


### PR DESCRIPTION
# Android Namespace Configuration Fix

## Description
Added proper namespace configuration to support newer Android Gradle Plugin requirements.

Changes made:
- Removed package attribute from AndroidManifest.xml
- Added namespace declaration in build.gradle
- Maintained original package name (xyz.justsoft.video_thumbnail)

## Why
This fix resolves build failures occurring with newer versions of the Android Gradle Plugin where namespace specification is required.

## Testing Done
- Tested with latest Flutter version
- Verified build succeeds on Android
- Verified existing functionality continues to work