### PR TITLE
replace jcenter() with mavenCentral()

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,7 +4,8 @@ version '1.0-SNAPSHOT'
 buildscript {
     repositories {
         google()
-        jcenter()
+//        jcenter()
+        mavenCentral()
     }
 
     dependencies {
@@ -15,7 +16,7 @@ buildscript {
 rootProject.allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 


### PR DESCRIPTION
due to error:
`Could not find method jcenter() for arguments [] on repository container of type org.gradle.api.internal.artifacts.dsl.DefaultRepositoryHandler.`
replace jcenter() with mavenCentral()
